### PR TITLE
upgrade of the org.openjfx.javafxplugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.9'
 }
 
 group 'edu.andreasgut'
@@ -23,7 +23,7 @@ test {
 }
 
 javafx{
-    modules = [ 'javafx.controls' , 'javafx.fxml', 'javafx.media']
+    modules = ['javafx.controls', 'javafx.fxml', 'javafx.media']
     version = '15.0.1'
 }
 


### PR DESCRIPTION
Gemäss https://plugins.gradle.org/plugin/org.openjfx.javafxplugin ist Version 0.0.9 die aktuellste Version.
Ich habe die Versionsnummer im build.gradle entsprechend angepasst (und auch getestet).